### PR TITLE
support python list in `write_json`

### DIFF
--- a/s3/s3.py
+++ b/s3/s3.py
@@ -764,7 +764,7 @@ class S3():
     def write_json(
         self,
         target: str,
-        content: Union[dict, str],
+        content: Union[dict, list, str],
         bucket: str = ''
     ) -> bool:
         """writes json from content to s3 file called target
@@ -772,7 +772,7 @@ class S3():
         Args:
             target (str): the absolute path to the file to write to, will overwrite if 
                 exists
-            content (Union[dict, str]): if a dict is provided it will be dumped to
+            content (Union[dict, list, str]): if a dict or a list is provided it will be dumped to
                 json, otherwise it assumes the json is properly formatted
             bucket (str, optional): the bucket to write to. Defaults to '', uses the
                 default bucket.
@@ -792,7 +792,7 @@ class S3():
             }
         """
         # if a dict is provided dump the content, otherwise assume valid json
-        json_content = json.dumps(content) if type(content) is dict else content
+        json_content = json.dumps(content) if type(content) is dict or list else content
         return self.write_to_file(
             filename=target,
             content=json_content,

--- a/s3/s3.py
+++ b/s3/s3.py
@@ -772,8 +772,8 @@ class S3():
         Args:
             target (str): the absolute path to the file to write to, will overwrite if 
                 exists
-            content (Union[dict, list, str]): if a dict or a list is provided it will be dumped to
-                json, otherwise it assumes the json is properly formatted
+            content (Union[dict, list, str]): if a dict or a list is provided it will
+                be dumped to json, otherwise it assumes the json is properly formatted
             bucket (str, optional): the bucket to write to. Defaults to '', uses the
                 default bucket.
 

--- a/tests/test_s3connector.py
+++ b/tests/test_s3connector.py
@@ -503,6 +503,18 @@ class TestS3():
         assert response
         assert json_content == s3_conn.read_json(target=new_json)
 
+    def test_write_json_list(self, s3_conn: S3, s3_test_setup):
+        json_content = [
+            'some', 'json'
+        ]
+        new_json = 'new_json.json'
+        response = s3_conn.write_json(
+            target=new_json,
+            content=json_content
+        )
+        assert response
+        assert json_content == s3_conn.read_json(target=new_json)
+
     def test_write_to_file(self, s3_conn: S3, s3_test_setup):
         file_content = json.dumps({'cont': 'ent'})
         filename = 'newfile.json'


### PR DESCRIPTION
- adds support for lists when using the `S3.write_json` method
- also a test