### PR TITLE
Bugfix for S3().delete_folder()

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Useful functions for communicating with S3, written in python 3.9.
 
 ## Including in your application:
 In your 'requirements.txt' (your pip install file):
-`-e git+https://github.com/BridgeMarketing/bridge-aws.git@v1.4.0#egg=bridge-aws`
+`-e git+https://github.com/BridgeMarketing/bridge-aws.git@v1.4.1#egg=bridge-aws`
 (Double check that the version after `git@` is the version you want.)
 
 After pip has successfully installed the useful object can be accessed with:

--- a/s3/s3.py
+++ b/s3/s3.py
@@ -1238,7 +1238,7 @@ class S3:
                 }
         """
         deleted_files = []
-        for file in self.list_folder_contents(path=target, delimiter=""):
+        for file in self.list_folder_contents(bucket=bucket or self.bucket, path=target, delimiter=""):
             deleted_files.append(
                 self.s3.delete_object(Bucket=bucket or self.bucket, Key=file)
             )

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 setup(
     name="bridge_aws",
     packages=find_packages(include=["s3"]),
-    version="v1.4.0",
+    version="v1.4.1",
     description="BRIDGE aws libraries, allows managing s3.",
     author="BRIDGE",
     license="GPL",
@@ -18,7 +18,7 @@ setup(
         "flake8-print",
         "flake8-debugger",
         "flake8-comprehensions",
-        "moto",
+        "moto>=2.2.13",
     ],
     test_suite="tests",
 )

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -95,6 +95,7 @@ class TestS3:
         assert set(result.keys()) == {
             "Body",
             "ContentLength",
+            "ContentType",
             "ETag",
             "LastModified",
             "Metadata",


### PR DESCRIPTION
This PR fixes a bug in `S3().delete_folder()`. When `delete_folder()` is called, the `bucket` parameter was not being used to list and delete the folder contents, causing the operation to fail with the following error message:

```
Invalid bucket name "": Bucket name must match the regex "^[a-zA-Z0-9.\-_]{1,255}$" or be an ARN matching the regex "^arn:(aws).*:(s3|s3-object-lambda):[a-z\-0-9]*:[0-9]{12}:accesspoint[/:][a-zA-Z0-9\-.]{1,63}$|^arn:(aws).*:s3-outposts:[a-z\-0-9]+:[0-9]{12}:outpost[/:][a-zA-Z0-9\-]{1,63}[/:]accesspoint[/:][a-zA-Z0-9\-]{1,63}$"
```

This PR resolves this issue.