### PR TITLE
Add 'extra_args' parameter for file uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Useful functions for communicating with S3, written in python 3.9.
 
 ## Including in your application:
 In your 'requirements.txt' (your pip install file):
-`-e git+https://github.com/BridgeMarketing/bridge-aws.git@v1.4.1#egg=bridge-aws`
+`-e git+https://github.com/BridgeMarketing/bridge-aws.git@v1.5.1#egg=bridge-aws`
 (Double check that the version after `git@` is the version you want.)
 
 After pip has successfully installed the useful object can be accessed with:

--- a/s3/s3.py
+++ b/s3/s3.py
@@ -1,7 +1,7 @@
 import json
 import os
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from typing import Generator, Iterable, List, Tuple, Union
+from typing import Generator, Iterable, List, Tuple, Union, Dict
 
 import boto3
 
@@ -944,7 +944,7 @@ class S3:
                 os.makedirs(os.path.join(local_path, s3_key))
         return True
 
-    def upload_file(self, target: str, local_path: str, bucket: str = "") -> bool:
+    def upload_file(self, target: str, local_path: str, bucket: str = "", extra_args: Dict = None) -> bool:
         """upload the file at local_path to the s3 location target in bucket
 
         Args:
@@ -952,17 +952,19 @@ class S3:
             local_path (str): where the file is on the local filesystem
             bucket (str, optional): the bucket to look in.
                 Defaults to '' which uses the default bucket.
+            extra_args (dict): keys & values to pass as extra arguments when uploading
+        (https://boto3.amazonaws.com/v1/documentation/api/latest/guide/s3-uploading-files.html#the-extraargs-parameter)
 
         Returns:
             bool: True if no exceptions were raised
         """
         self.s3.upload_file(
-            Filename=local_path, Bucket=bucket or self.bucket, Key=target
+            Filename=local_path, Bucket=bucket or self.bucket, Key=target, ExtraArgs=extra_args if extra_args else {}
         )
         return True
 
     def upload_files(
-        self, local_to_s3: List[Tuple[str, str]], bucket: str = "", max_workers: int = 3
+        self, local_to_s3: List[Tuple[str, str]], bucket: str = "", max_workers: int = 3, extra_args: Dict = None
     ) -> Tuple[List[str], List[str]]:
         """uploads one or more files to the specified locations
 
@@ -973,6 +975,8 @@ class S3:
                 Defaults to '', which uses the default bucket.
             max_workers (int, optional): how many workers to allow for the threadpool.
                 Defaults to 3.
+            extra_args (dict): keys & values to pass as extra arguments when uploading
+        (https://boto3.amazonaws.com/v1/documentation/api/latest/guide/s3-uploading-files.html#the-extraargs-parameter)
 
         Returns:
             dict: the dictionary maps the upload to the result (boolean)
@@ -987,7 +991,8 @@ class S3:
             for local_file, s3_target in local_to_s3:
                 future = executor.submit(
                     self.upload_file,
-                    **{"target": s3_target, "local_path": local_file, "bucket": bucket},
+                    **{"target": s3_target, "local_path": local_file, "bucket": bucket,
+                       "ExtraArgs": extra_args if extra_args else {}},
                 )
                 future.id = (local_file, s3_target)
                 futures.append(future)
@@ -997,13 +1002,15 @@ class S3:
 
         return results
 
-    def upload_folder(self, target: str, local_path: str, bucket: str = "") -> bool:
+    def upload_folder(self, target: str, local_path: str, bucket: str = "", extra_args: Dict = None) -> bool:
         """Upload the contents of the folder at local_path to the s3 location target in bucket
 
         Args:
             target (str): the s3 key, ending in / to upload the files to
             local_path (str): where on the local filesystem the files to upload are
             bucket (str, optional): the bucket to look in. Defaults to ''.
+            extra_args (dict): keys & values to pass as extra arguments when uploading
+        (https://boto3.amazonaws.com/v1/documentation/api/latest/guide/s3-uploading-files.html#the-extraargs-parameter)
 
         Raises:
             FileNotFoundError: Cannot find the file on the local filesystem
@@ -1022,6 +1029,7 @@ class S3:
                     target=os.path.join(target, os.path.join(root, file)),
                     local_path=os.path.join(root, file),
                     bucket=bucket,
+                    extra_args=extra_args
                 )
         return True
 

--- a/s3/s3.py
+++ b/s3/s3.py
@@ -975,7 +975,8 @@ class S3:
                 Defaults to '', which uses the default bucket.
             max_workers (int, optional): how many workers to allow for the threadpool.
                 Defaults to 3.
-            extra_args (dict): keys & values to pass as extra arguments when uploading
+            extra_args (dict): keys & values to pass as extra arguments when uploading each file. Same parameters will
+            be used for all files.
         (https://boto3.amazonaws.com/v1/documentation/api/latest/guide/s3-uploading-files.html#the-extraargs-parameter)
 
         Returns:
@@ -1009,7 +1010,8 @@ class S3:
             target (str): the s3 key, ending in / to upload the files to
             local_path (str): where on the local filesystem the files to upload are
             bucket (str, optional): the bucket to look in. Defaults to ''.
-            extra_args (dict): keys & values to pass as extra arguments when uploading
+            extra_args (dict): keys & values to pass as extra arguments when uploading each file. Same parameters will
+            be used for all files.
         (https://boto3.amazonaws.com/v1/documentation/api/latest/guide/s3-uploading-files.html#the-extraargs-parameter)
 
         Raises:

--- a/s3/s3.py
+++ b/s3/s3.py
@@ -993,7 +993,7 @@ class S3:
                 future = executor.submit(
                     self.upload_file,
                     **{"target": s3_target, "local_path": local_file, "bucket": bucket,
-                       "ExtraArgs": extra_args if extra_args else {}},
+                       "extra_args": extra_args if extra_args else {}},
                 )
                 future.id = (local_file, s3_target)
                 futures.append(future)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 setup(
     name="bridge_aws",
     packages=find_packages(include=["s3"]),
-    version="v1.4.1",
+    version="v1.5.1",
     description="BRIDGE aws libraries, allows managing s3.",
     author="BRIDGE",
     license="GPL",


### PR DESCRIPTION
This PR adds the ability to pass an "extra_args" dict to S3.upload_file(), S3.upload_files(), and S3.upload_folder(). [See this page](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/s3-uploading-files.html#the-extraargs-parameter) for more information on this option.