### PR TITLE
Bugfix for fetching from directories with > 1000 files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "s3-connector"
-version = "1.6.0"
+version = "1.6.1"
 license = "GPL"
 description = "BRIDGE s3 connector, allows managing s3."
 readme = "README.md"

--- a/s3/s3.py
+++ b/s3/s3.py
@@ -468,7 +468,7 @@ class S3:
             objs = self.s3.list_objects_v2(**kwargs)
             for obj in objs.get("Contents", []):
                 yield obj.get("Key")
-            if not objs.get("isTruncated"):
+            if not objs.get("IsTruncated"):
                 break
             continuation_token = objs.get("NextContinuationToken")
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 setup(
     name="bridge_aws",
     packages=find_packages(include=["s3"]),
-    version="v1.6.0",
+    version="v1.6.1",
     description="BRIDGE aws libraries, allows managing s3.",
     author="BRIDGE",
     license="GPL",


### PR DESCRIPTION
S3.list_objects() fails to list all objects in paths containing more than 1000 files. It has the correct logic to retrieve all files, but one of the parameters was misnamed, causing the operation to fail silently. This PR fixes the issue and has been tested to ensure that S3.list_objects() now lists all the files in directories with more than 1000 files.